### PR TITLE
added some checks.

### DIFF
--- a/unClass-jar/ReplaceJarFileWithPatchFile.ps1
+++ b/unClass-jar/ReplaceJarFileWithPatchFile.ps1
@@ -1,5 +1,10 @@
 # Renames each patch file in folder to file. Create a backup file of file. 
 # If backup file already exists, delete it first unless SkipPatchFileIfPreviousBackupFileExists
+#
+# Changes from first version to V2:
+# - Default behaviour is changed to NOT remove the backup file if it exists. Instead it skips the patch file.
+# This will prevent the original backed-up file from being lost forever. 
+# - Remove leading dots from file extension parameters (if any)
 Function ReplaceJarFileWithPatchFile
 {
     Param
@@ -9,7 +14,8 @@ Function ReplaceJarFileWithPatchFile
         $PatchFileExtension,  # Ex. jar.patch (no leading dot)
         $BackupFileExtension, # Ex. jar.bak (no leading dot)        
         $FileStartsWith,      # Ex. log4j- (no wildcards, the function adds wildcards)
-        [switch]$SkipPatchFileIfPreviousBackupFileExists, # If this is set, do not delete a previously made backup file and skip the rename action for the current patch file
+        [switch]$SkipPatchFileIfPreviousBackupFileExists, # If this is set, do not delete a previously made backup file and skip the rename action for the current patch file V2: this is the default action now
+        [siwtch]$ReplacePreviousBackupFile, # Override default behaviour
         [switch]$Verbose,     # Show verbose logging
         [switch]$Recurse,     # Also search all subfolders of folder
         [switch]$Debug        # Pretend to rename files, but don't rename of delete anything
@@ -34,6 +40,11 @@ Function ReplaceJarFileWithPatchFile
         Write-Verbose "Number of patch files found in folder: $nrPatchFiles"
     }
 
+    # Remove leading dot from extension, if any
+    $FileExtension = $FileExtension.TrimStart('.')
+    $PatchFileExtension = $PatchFileExtension.TrimStart('.')
+    $BackupFileExtension = $BackupFileExtension.TrimStart('.')
+
     # Rename file to backupfile, rename patch file to file
     foreach ($patchFile in $patchFilesFound)
     {
@@ -57,13 +68,7 @@ Function ReplaceJarFileWithPatchFile
             # Delete the backup file (or not) if it exists
             if ($matchingBackupFile)
             {
-                if ($SkipPatchFileIfPreviousBackupFileExists)
-                {
-                    Write-Verbose "Backup file of matching file found: $matchingBackupFile"
-                    Write-Output "Backup file $matchingBackupFile already exists, but skipping the rename action for this patch file because of parameter SkipPatchFileIfPreviousBackupFileExists"
-                    Continue # Go to next loop iteration, because this patch file is skipped
-                }
-                else
+                if ($ReplacePreviousBackupFile)
                 {
                     if (!$Debug)
                     {
@@ -75,7 +80,12 @@ Function ReplaceJarFileWithPatchFile
                     {
                         Write-Output "Debug: Previous backup file would have been deleted"
                     }
-
+                }
+                else
+                {
+                    Write-Verbose "Backup file of matching file found: $matchingBackupFile"
+                    Write-Output "Backup file $matchingBackupFile already exists, skipping this patch file (override possible with -ReplacePreviousBackupFile)"
+                    Continue # Go to next loop iteration, because this patch file is skipped
                 }
             }
             else
@@ -95,8 +105,7 @@ Function ReplaceJarFileWithPatchFile
             $patchFileName = $patchFile.Name
 
             if (!$Debug)
-            {
-                        
+            {                        
                 # Rename file to backup file
                 Rename-Item -Path $originalFileNameFullPath -NewName $newBackupFileName
                 Write-Output "Renamed $originalFileNameFullPath to $newBackupFileName"
@@ -110,7 +119,6 @@ Function ReplaceJarFileWithPatchFile
                 Write-Output "Debug: Would have renamed $originalFileNameFullPath to $newBackupFileName"
                 Write-Output "Debug: Would have renamed $patchFileNameFullPath to $originalFileName"
             }
-
         }
         else
         {
@@ -119,4 +127,48 @@ Function ReplaceJarFileWithPatchFile
     }
 }
 
-## Script by anonymous collaborator - OGD ICT Diensten
+<#
+Example:
+
+$folder = '.\log4jtest\'
+$fileExtension = 'jar'
+$patchFileExtension = 'jar.patch'
+$backupFileExtension = 'jar.bak'
+$fileStartsWith = 'log4j-core'
+ReplaceJarFileWithPatchFile -Folder $folder -FileExtension $fileExtension -PatchFileExtension $patchFileExtension -BackupFileExtension $backupFileExtension -FileStartsWith $fileStartsWith -Verbose -Recurse -Debug
+
+Example output:
+VERBOSE: Number of patch files found in folder and subfolders: 2
+VERBOSE: Current patch file is located in directory: C:\log4jtest
+VERBOSE: Current patch file name: log4j-core.jar.patch
+VERBOSE: Looking for log4j-core.jar
+VERBOSE: Matching file found: log4j-core.jar
+VERBOSE: Backup file of matching file log4j-core.jar does not exist yet
+Debug: Would have renamed C:\log4jtest\log4j-core.jar to log4j-core.jar.bak
+Debug: Would have renamed C:\log4jtest\log4j-core.jar.patch to log4j-core.jar
+VERBOSE: Current patch file is located in directory: C:\log4jtest\recursion test\somefolder
+VERBOSE: Current patch file name: log4j-core.jar.patch
+VERBOSE: Looking for log4j-core.jar
+VERBOSE: Matching file found: log4j-core.jar
+VERBOSE: Backup file of matching file log4j-core.jar does not exist yet
+Debug: Would have renamed C:\log4jtest\recursion test\somefolder\log4j-core.jar to log4j-core.jar.bak
+Debug: Would have renamed C:\log4jtest\recursion test\somefolder\log4j-core.jar.patch to log4j-core.jar
+
+Example non debug output:
+VERBOSE: Number of patch files found in folder and subfolders: 2
+VERBOSE: Current patch file is located in directory: C:\log4jtest
+VERBOSE: Current patch file name: log4j-core.jar.patch
+VERBOSE: Looking for log4j-core.jar
+VERBOSE: Matching file found: log4j-core.jar
+VERBOSE: Backup file of matching file log4j-core.jar does not exist yet
+Renamed C:\log4jtest\log4j-core.jar to log4j-core.jar.bak
+Renamed C:\log4jtest\log4j-core.jar.patch to log4j-core.jar
+VERBOSE: Current patch file is located in directory: C:\log4jtest\recursion test\somefolder
+VERBOSE: Current patch file name: log4j-core.jar.patch
+VERBOSE: Looking for log4j-core.jar
+VERBOSE: Matching file found: log4j-core.jar
+VERBOSE: Backup file of matching file log4j-core.jar does not exist yet
+Renamed C:\log4jtest\recursion test\somefolder\log4j-core.jar to log4j-core.jar.bak
+Renamed C:\log4jtest\recursion test\somefolder\log4j-core.jar.patch to log4j-core.jar
+#>
+


### PR DESCRIPTION
Changes from first version to V2:
# - Default behaviour is changed to NOT remove the backup file if it exists. Instead it skips the patch file.
# This will prevent the original backed-up file from being lost forever. 
# - Remove leading dots from file extension parameters (if any)